### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,6 +2,6 @@ AH_28BYJ-48	KEYWORD1
 
 setSpeedRPM	KEYWORD2
 setSpeedHz	KEYWORD2
-step		KEYWORD2
-step_noblock    KEYWORD2
+step	KEYWORD2
+step_noblock	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords